### PR TITLE
Add pricing route with subscription tiers

### DIFF
--- a/src/router.tsx
+++ b/src/router.tsx
@@ -18,6 +18,7 @@ import { ModeToggle } from '@/components/mode-toggle'
 
 import { HomeRoute } from './routes/index'
 import { LoginRoute } from './routes/login'
+import { PricingRoute } from './routes/pricing'
 import { SignUpRoute } from './routes/sign-up'
 
 const rootRoute = new RootRoute({
@@ -42,19 +43,30 @@ const rootRoute = new RootRoute({
                 >
                   Overview
                 </Link>
+                <Link
+                  to="/pricing"
+                  className="transition hover:text-foreground"
+                  activeProps={{ className: 'text-foreground transition hover:text-foreground' }}
+                >
+                  Pricing
+                </Link>
                 <SignedOut>
                   <>
                     <Link
                       to="/login"
                       className="transition hover:text-foreground"
-                      activeProps={{ className: 'text-foreground transition hover:text-foreground' }}
+                      activeProps={{
+                        className: 'text-foreground transition hover:text-foreground',
+                      }}
                     >
                       Log in
                     </Link>
                     <Link
                       to="/sign-up"
                       className="transition hover:text-foreground"
-                      activeProps={{ className: 'text-foreground transition hover:text-foreground' }}
+                      activeProps={{
+                        className: 'text-foreground transition hover:text-foreground',
+                      }}
                     >
                       Sign up
                     </Link>
@@ -105,7 +117,10 @@ const rootRoute = new RootRoute({
                 </Button>
               </SignedOut>
               <SignedIn>
-                <UserButton afterSignOutUrl="/" appearance={{ elements: { userButtonAvatarBox: 'h-8 w-8' } }} />
+                <UserButton
+                  afterSignOutUrl="/"
+                  appearance={{ elements: { userButtonAvatarBox: 'h-8 w-8' } }}
+                />
               </SignedIn>
               <ModeToggle />
             </div>
@@ -154,7 +169,13 @@ const signUpRoute = new Route({
   component: SignUpRoute,
 })
 
-const routeTree = rootRoute.addChildren([indexRoute, loginRoute, signUpRoute])
+const pricingRoute = new Route({
+  getParentRoute: () => rootRoute,
+  path: '/pricing',
+  component: PricingRoute,
+})
+
+const routeTree = rootRoute.addChildren([indexRoute, pricingRoute, loginRoute, signUpRoute])
 
 const router = createRouter({ routeTree })
 

--- a/src/routes/pricing.tsx
+++ b/src/routes/pricing.tsx
@@ -1,0 +1,233 @@
+import React from 'react'
+import { Link } from '@tanstack/react-router'
+import { ArrowRight, Check, LifeBuoy, ShieldCheck, Sparkles } from 'lucide-react'
+
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import { cn } from '@/lib/utils'
+
+const plans = [
+  {
+    name: 'Starter',
+    price: '$0',
+    priceSuffix: 'per month',
+    description: 'Perfect for individuals exploring a new project or validating an idea.',
+    features: [
+      'Up to 3 live projects with fast builds',
+      'Collaborative dashboard for 2 teammates',
+      'Community Slack access and office hours',
+      'Email support with 48 hour response time',
+    ],
+    cta: 'Start for free',
+    href: '/sign-up',
+    buttonVariant: 'outline' as const,
+  },
+  {
+    name: 'Growth',
+    price: '$24',
+    priceSuffix: 'per month',
+    description: 'Built for growing teams that need advanced workflows and insight.',
+    features: [
+      'Unlimited projects with preview deployments',
+      'Automation rules and branch-based environments',
+      'Integrations with Slack, Linear, and GitHub',
+      'Priority email and chat support',
+    ],
+    cta: 'Upgrade to Growth',
+    href: '/sign-up',
+    highlighted: true,
+  },
+  {
+    name: 'Scale',
+    price: '$79',
+    priceSuffix: 'per month',
+    description: 'For product-led organizations that require enterprise-grade controls.',
+    features: [
+      'SAML SSO and granular role-based permissions',
+      'Uptime SLAs with dedicated success manager',
+      'Regional edge deployments with analytics',
+      'Quarterly architecture reviews and roadmap input',
+    ],
+    cta: 'Talk to sales',
+    href: 'mailto:hello@example.com',
+    external: true,
+    buttonVariant: 'secondary' as const,
+  },
+]
+
+const guarantees = [
+  {
+    title: '30-day satisfaction guarantee',
+    description:
+      'Try any paid plan for a full month. If it does not fit, we will refund your most recent payment—no questions asked.',
+    icon: ShieldCheck,
+  },
+  {
+    title: 'Always available help',
+    description:
+      'Our global support engineers respond around the clock to keep your deployment pipeline healthy and performant.',
+    icon: LifeBuoy,
+  },
+]
+
+export function PricingRoute() {
+  return (
+    <div className="space-y-12">
+      <section className="mx-auto flex max-w-3xl flex-col items-center gap-6 text-center">
+        <Badge variant="outline" className="border-primary/50 text-primary">
+          Pricing
+        </Badge>
+        <div className="space-y-4">
+          <h1 className="text-3xl font-semibold tracking-tight sm:text-4xl md:text-5xl">
+            Flexible plans that scale with your team
+          </h1>
+          <p className="text-base text-muted-foreground sm:text-lg">
+            Move from idea to production with predictable pricing. Every plan uses the same fast
+            infrastructure so you can build and ship without trade-offs.
+          </p>
+        </div>
+        <div className="inline-flex items-center gap-2 rounded-full border border-primary/20 bg-primary/5 px-4 py-2 text-sm text-primary">
+          <Sparkles className="h-4 w-4" />
+          Cancel or change plans at any time—no hidden fees.
+        </div>
+      </section>
+
+      <section className="grid gap-6 md:grid-cols-3">
+        {plans.map((plan) => (
+          <Card
+            key={plan.name}
+            className={cn(
+              'relative flex h-full flex-col border-muted/70 bg-card/90 shadow-sm backdrop-blur',
+              plan.highlighted &&
+                'border-primary shadow-lg shadow-primary/20 ring-1 ring-primary/30 md:-translate-y-2 md:scale-[1.02] md:shadow-xl',
+            )}
+          >
+            {plan.highlighted ? (
+              <div className="absolute -top-3 left-1/2 w-fit -translate-x-1/2">
+                <Badge className="bg-primary text-primary-foreground shadow">Most popular</Badge>
+              </div>
+            ) : null}
+
+            <CardHeader className="space-y-3">
+              <CardTitle className="text-2xl">{plan.name}</CardTitle>
+              <CardDescription>{plan.description}</CardDescription>
+            </CardHeader>
+            <CardContent className="flex flex-1 flex-col gap-6">
+              <div className="flex items-end justify-between">
+                <div className="flex items-baseline gap-2">
+                  <span className="text-4xl font-semibold sm:text-5xl">{plan.price}</span>
+                  <span className="text-sm font-medium text-muted-foreground">
+                    {plan.priceSuffix}
+                  </span>
+                </div>
+                {plan.highlighted ? (
+                  <Badge variant="secondary" className="bg-secondary/70 text-secondary-foreground">
+                    Save 20%
+                  </Badge>
+                ) : null}
+              </div>
+              <div className="h-px bg-muted/70" />
+              <ul className="space-y-3 text-sm text-muted-foreground">
+                {plan.features.map((feature) => (
+                  <li key={feature} className="flex gap-3 text-left">
+                    <span className="mt-0.5 inline-flex h-5 w-5 items-center justify-center rounded-full bg-primary/10 text-primary">
+                      <Check className="h-3.5 w-3.5" />
+                    </span>
+                    <span>{feature}</span>
+                  </li>
+                ))}
+              </ul>
+            </CardContent>
+            <CardFooter>
+              <Button className="w-full" variant={plan.buttonVariant ?? 'default'} asChild>
+                {plan.external ? (
+                  <a href={plan.href}>
+                    {plan.cta}
+                    <ArrowRight className="ml-2 h-4 w-4" />
+                  </a>
+                ) : (
+                  <Link to={plan.href}>
+                    {plan.cta}
+                    <ArrowRight className="ml-2 h-4 w-4" />
+                  </Link>
+                )}
+              </Button>
+            </CardFooter>
+          </Card>
+        ))}
+      </section>
+
+      <section className="grid gap-6 md:grid-cols-[2fr,1fr]">
+        <Card className="border-dashed border-muted/70 bg-card/80">
+          <CardHeader className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div className="space-y-1">
+              <CardTitle className="text-2xl">All plans include</CardTitle>
+              <CardDescription>
+                Deploy instantly, collaborate with your team, and stay confident with built-in
+                observability across every tier.
+              </CardDescription>
+            </div>
+            <Button variant="outline" asChild>
+              <Link to="/login" className="flex items-center gap-1">
+                View dashboard
+                <ArrowRight className="h-4 w-4" />
+              </Link>
+            </Button>
+          </CardHeader>
+          <CardContent className="grid gap-4 sm:grid-cols-2">
+            {[
+              'Unlimited previews and instant rollbacks',
+              'Role-based access control out of the box',
+              'Performance analytics with retention cohorts',
+              'Global edge network with smart caching',
+            ].map((benefit) => (
+              <div key={benefit} className="flex items-start gap-3 text-sm text-muted-foreground">
+                <span className="mt-0.5 inline-flex h-5 w-5 items-center justify-center rounded-full bg-primary/10 text-primary">
+                  <Check className="h-3.5 w-3.5" />
+                </span>
+                <span>{benefit}</span>
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+        <Card className="border-muted/70 bg-card/80">
+          <CardHeader className="space-y-4">
+            <CardTitle className="text-xl">We are on your side</CardTitle>
+            <CardDescription>
+              Whether you are just getting started or migrating an enterprise workload, we partner
+              with your team from day one.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-5">
+            {guarantees.map((guarantee) => (
+              <div key={guarantee.title} className="flex gap-3 text-sm text-muted-foreground">
+                <span className="mt-0.5 inline-flex h-9 w-9 items-center justify-center rounded-full bg-primary/10 text-primary">
+                  <guarantee.icon className="h-4 w-4" />
+                </span>
+                <div className="space-y-1">
+                  <p className="font-medium text-foreground">{guarantee.title}</p>
+                  <p>{guarantee.description}</p>
+                </div>
+              </div>
+            ))}
+          </CardContent>
+          <CardFooter>
+            <Button className="w-full" variant="secondary" asChild>
+              <Link to="/sign-up">Chat with our team</Link>
+            </Button>
+          </CardFooter>
+        </Card>
+      </section>
+    </div>
+  )
+}
+
+export default PricingRoute


### PR DESCRIPTION
## Summary
- add a dedicated `/pricing` route with hero, plan tiers, and guarantee messaging
- register the pricing page in the router and expose it from the primary navigation

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cec08df7248329b253c1d70b9435cd