### PR TITLE
Integrate TanStack Form into auth flows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@clerk/clerk-react": "^5.47.0",
         "@radix-ui/react-slot": "^1.0.2",
+        "@tanstack/react-form": "^1.23.0",
         "@tanstack/react-query": "^5.45.0",
         "@tanstack/react-query-devtools": "^5.45.0",
         "@tanstack/react-router": "^1.46.1",
@@ -2934,6 +2935,34 @@
         "@swc/counter": "^0.1.3"
       }
     },
+    "node_modules/@tanstack/devtools-event-client": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@tanstack/devtools-event-client/-/devtools-event-client-0.2.5.tgz",
+      "integrity": "sha512-iVdqw879KETXyyPHc3gQR5Ld0GjlPLk7bKenBUhzr3+z1FiQZvsbfgYfRRokTSPcgwANAV7aA2Uv05nx5xWT8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/form-core": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/form-core/-/form-core-1.23.0.tgz",
+      "integrity": "sha512-aBJnO5iA1TtMK/SSpAvd/y6cVsBgbu5Br2FftvW6r7TkHCcZ/lB2DMx3G2dk6SG7sW0g8s6F7iaMjrvqBGooDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/devtools-event-client": "^0.2.5",
+        "@tanstack/store": "^0.7.5",
+        "uuid": "^13.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
     "node_modules/@tanstack/history": {
       "version": "1.131.2",
       "resolved": "https://registry.npmjs.org/@tanstack/history/-/history-1.131.2.tgz",
@@ -2965,6 +2994,31 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-form": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-form/-/react-form-1.23.0.tgz",
+      "integrity": "sha512-wZ/cBjqj5dgWG79TQOsilbs8WzdouJj3iXw1DAZvQ4nejobsTGl0huU7SZZ0mnFtdNHbre1bFSdWyw+GqFcIhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/form-core": "1.23.0",
+        "@tanstack/react-store": "^0.7.5",
+        "decode-formdata": "^0.9.0",
+        "devalue": "^5.3.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-start": "^1.130.10",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@tanstack/react-start": {
+          "optional": true
+        }
       }
     },
     "node_modules/@tanstack/react-query": {
@@ -5157,6 +5211,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/decode-formdata": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/decode-formdata/-/decode-formdata-0.9.0.tgz",
+      "integrity": "sha512-q5uwOjR3Um5YD+ZWPOF/1sGHVW9A5rCrRwITQChRXlmPkxDFBqCm4jNTIVdGHNH9OnR+V9MoZVgRhsFb+ARbUw==",
+      "license": "MIT"
+    },
     "node_modules/decode-named-character-reference": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.2.0.tgz",
@@ -5320,6 +5380,12 @@
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
       }
+    },
+    "node_modules/devalue": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.3.2.tgz",
+      "integrity": "sha512-UDsjUbpQn9kvm68slnrs+mfxwFkIflOhkanmyabZ8zOYk8SMEIbJ3TK+88g70hSIeytu4y18f0z/hYHMTrXIWw==",
+      "license": "MIT"
     },
     "node_modules/devlop": {
       "version": "1.1.0",
@@ -12470,6 +12536,19 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
+      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
     },
     "node_modules/vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@clerk/clerk-react": "^5.47.0",
     "@radix-ui/react-slot": "^1.0.2",
+    "@tanstack/react-form": "^1.23.0",
     "@tanstack/react-query": "^5.45.0",
     "@tanstack/react-query-devtools": "^5.45.0",
     "@tanstack/react-router": "^1.46.1",

--- a/src/routes/login.tsx
+++ b/src/routes/login.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Link, useNavigate } from '@tanstack/react-router'
+import { useForm, useStore } from '@tanstack/react-form'
 import { ClerkLoaded, ClerkLoading, useSignIn } from '@/lib/clerk'
 import { AlertCircle, LogIn, ShieldCheck } from 'lucide-react'
 
@@ -21,26 +22,24 @@ import { getClerkErrorMessage } from '@/lib/clerk'
 export function LoginRoute() {
   const { isLoaded, signIn, setActive } = useSignIn()
   const navigate = useNavigate()
-  const [email, setEmail] = React.useState('')
-  const [password, setPassword] = React.useState('')
   const [errorMessage, setErrorMessage] = React.useState<string | null>(null)
-  const [isSubmitting, setIsSubmitting] = React.useState(false)
 
-  const handleSubmit = React.useCallback(
-    async (event: React.FormEvent<HTMLFormElement>) => {
-      event.preventDefault()
-
+  const loginForm = useForm({
+    defaultValues: {
+      email: '',
+      password: '',
+    },
+    onSubmit: async ({ value }) => {
       if (!isLoaded || !signIn) {
         return
       }
 
-      setIsSubmitting(true)
       setErrorMessage(null)
 
       try {
         const result = await signIn.create({
-          identifier: email,
-          password,
+          identifier: value.email,
+          password: value.password,
         })
 
         if (result.status === 'complete') {
@@ -49,17 +48,18 @@ export function LoginRoute() {
           return
         }
 
-        setErrorMessage('Additional steps are required to finish signing in. Please continue in the Clerk modal.')
+        setErrorMessage(
+          'Additional steps are required to finish signing in. Please continue in the Clerk modal.',
+        )
       } catch (error) {
         setErrorMessage(
           getClerkErrorMessage(error) ?? 'Something went wrong while signing in. Please try again.',
         )
-      } finally {
-        setIsSubmitting(false)
       }
     },
-    [email, isLoaded, navigate, password, setActive, signIn],
-  )
+  })
+
+  const isSubmitting = useStore(loginForm.store, (state) => state.isSubmitting)
 
   return (
     <div className="mx-auto grid max-w-5xl gap-10 md:grid-cols-[1.05fr,0.95fr]">
@@ -85,38 +85,56 @@ export function LoginRoute() {
             </div>
           </ClerkLoading>
           <ClerkLoaded>
-            <form className="space-y-5" onSubmit={handleSubmit}>
-              <div className="grid gap-2">
-                <Label htmlFor="login-email">Email address</Label>
-                <Input
-                  id="login-email"
-                  type="email"
-                  inputMode="email"
-                  autoComplete="email"
-                  placeholder="you@example.com"
-                  value={email}
-                  onChange={(event) => setEmail(event.target.value)}
-                  disabled={isSubmitting}
-                  required
-                />
-              </div>
-              <div className="grid gap-2">
-                <div className="flex items-center justify-between">
-                  <Label htmlFor="login-password">Password</Label>
-                  <Button variant="link" size="sm" className="h-auto px-0 font-normal" type="button">
-                    Forgot password?
-                  </Button>
-                </div>
-                <Input
-                  id="login-password"
-                  type="password"
-                  autoComplete="current-password"
-                  value={password}
-                  onChange={(event) => setPassword(event.target.value)}
-                  disabled={isSubmitting}
-                  required
-                />
-              </div>
+            <form
+              className="space-y-5"
+              onSubmit={(event) => {
+                event.preventDefault()
+                void loginForm.handleSubmit()
+              }}
+            >
+              <loginForm.Field name="email">
+                {(field) => (
+                  <div className="grid gap-2">
+                    <Label htmlFor="login-email">Email address</Label>
+                    <Input
+                      id="login-email"
+                      name={field.name}
+                      type="email"
+                      inputMode="email"
+                      autoComplete="email"
+                      placeholder="you@example.com"
+                      value={field.state.value}
+                      onBlur={field.handleBlur}
+                      onChange={(event) => field.handleChange(event.target.value)}
+                      disabled={isSubmitting}
+                      required
+                    />
+                  </div>
+                )}
+              </loginForm.Field>
+              <loginForm.Field name="password">
+                {(field) => (
+                  <div className="grid gap-2">
+                    <div className="flex items-center justify-between">
+                      <Label htmlFor="login-password">Password</Label>
+                      <Button variant="link" size="sm" className="h-auto px-0 font-normal" type="button">
+                        Forgot password?
+                      </Button>
+                    </div>
+                    <Input
+                      id="login-password"
+                      name={field.name}
+                      type="password"
+                      autoComplete="current-password"
+                      value={field.state.value}
+                      onBlur={field.handleBlur}
+                      onChange={(event) => field.handleChange(event.target.value)}
+                      disabled={isSubmitting}
+                      required
+                    />
+                  </div>
+                )}
+              </loginForm.Field>
               {errorMessage ? (
                 <div
                   className="flex items-start gap-2 rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive"


### PR DESCRIPTION
## Summary
- add the @tanstack/react-form dependency
- refactor the login route to use TanStack Form for field state and submission
- wire the sign-up and verification steps into TanStack Form for consistent handling

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cec02c2e90832994287b91f98bf173