### PR TITLE
Add lint and type check stages to CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,8 @@ on:
   pull_request:
 
 jobs:
-  build:
+  lint:
+    name: Lint
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -23,6 +24,44 @@ jobs:
 
       - name: Run lint
         run: npm run lint
+
+  typecheck:
+    name: Type Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run type check
+        run: npm run typecheck
+
+  build:
+    name: Test and Build
+    runs-on: ubuntu-latest
+    needs:
+      - lint
+      - typecheck
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
 
       - name: Run tests
         run: npm run test

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "ladle:build": "ladle build",
     "ladle:preview": "ladle preview",
     "lint": "eslint . --ext .ts,.tsx --max-warnings=0",
+    "typecheck": "tsc --noEmit",
     "lint:fix": "npm run lint -- --fix",
     "lint:staged": "lint-staged",
     "format": "prettier --write .",


### PR DESCRIPTION
## Summary
- add dedicated lint and type check jobs to the CI workflow and require them before tests/build
- expose an npm script for running the project type check outside of the build step

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68ced06aac548329816a182a765cd361