### PR TITLE
Remove unused dependencies and React imports

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -38,6 +38,7 @@ export default [
       ...tsPlugin.configs.recommended.rules,
       ...reactPlugin.configs.recommended.rules,
       ...reactHooks.configs.recommended.rules,
+      'react/react-in-jsx-scope': 'off',
       'react/prop-types': 'off',
     },
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "@tanstack/react-query-devtools": "^5.45.0",
         "@tanstack/react-router": "^1.46.1",
         "@tanstack/router-devtools": "^1.46.1",
-        "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
         "lucide-react": "^0.424.0",
         "next-themes": "^0.4.6",
@@ -44,7 +43,6 @@
         "prettier": "^3.6.2",
         "shadcn-ui": "^0.9.5",
         "tailwindcss": "^3.4.3",
-        "tailwindcss-animate": "^1.0.7",
         "typescript": "^5.4.2",
         "vite": "^5.1.0",
         "vitest": "^3.2.4"
@@ -4704,18 +4702,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/class-variance-authority": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
-      "integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "clsx": "^2.1.1"
-      },
-      "funding": {
-        "url": "https://polar.sh/cva"
       }
     },
     "node_modules/classnames": {
@@ -11915,16 +11901,6 @@
       },
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/tailwindcss-animate": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/tailwindcss-animate/-/tailwindcss-animate-1.0.7.tgz",
-      "integrity": "sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "tailwindcss": ">=3.0.0 || insiders"
       }
     },
     "node_modules/thenify": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "@tanstack/react-query-devtools": "^5.45.0",
     "@tanstack/react-router": "^1.46.1",
     "@tanstack/router-devtools": "^1.46.1",
-    "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
     "lucide-react": "^0.424.0",
     "next-themes": "^0.4.6",
@@ -56,7 +55,6 @@
     "prettier": "^3.6.2",
     "shadcn-ui": "^0.9.5",
     "tailwindcss": "^3.4.3",
-    "tailwindcss-animate": "^1.0.7",
     "typescript": "^5.4.2",
     "vite": "^5.1.0",
     "vitest": "^3.2.4"

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { Outlet, RouterProvider, RootRoute, Route, createRouter } from '@tanstack/react-router'
 import { TanStackRouterDevtools } from '@tanstack/router-devtools'
 

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { Link } from '@tanstack/react-router'
 import { useQuery } from '@tanstack/react-query'
 import { ArrowRight, Layers3, LayoutDashboard, LineChart, Rocket } from 'lucide-react'

--- a/src/routes/marketing-layout.tsx
+++ b/src/routes/marketing-layout.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { Link, Outlet } from '@tanstack/react-router'
 import { Sparkles } from 'lucide-react'
 

--- a/src/routes/pricing.tsx
+++ b/src/routes/pricing.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { Link } from '@tanstack/react-router'
 import { ArrowRight, Check, LifeBuoy, ShieldCheck, Sparkles } from 'lucide-react'
 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,5 +1,4 @@
 import type { Config } from 'tailwindcss'
-import animatePlugin from 'tailwindcss-animate'
 
 const config: Config = {
   darkMode: ['class'],
@@ -53,23 +52,8 @@ const config: Config = {
         md: 'calc(var(--radius) - 2px)',
         sm: 'calc(var(--radius) - 4px)',
       },
-      keyframes: {
-        'accordion-down': {
-          from: { height: '0' },
-          to: { height: 'var(--radix-accordion-content-height)' },
-        },
-        'accordion-up': {
-          from: { height: 'var(--radix-accordion-content-height)' },
-          to: { height: '0' },
-        },
-      },
-      animation: {
-        'accordion-down': 'accordion-down 0.2s ease-out',
-        'accordion-up': 'accordion-up 0.2s ease-out',
-      },
     },
   },
-  plugins: [animatePlugin],
 }
 
 export default config


### PR DESCRIPTION
## Summary
- remove unused packages class-variance-authority and tailwindcss-animate
- drop the unused tailwind animation helpers that relied on the removed plugin
- disable the legacy react-in-jsx-scope lint rule so redundant React imports can be deleted

## Testing
- npm run lint
- npm run typecheck
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cfd37b3df08329abea47a559a807ef