### PR TITLE
Add Playwright auth E2E tests and mocked Clerk provider

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,3 +77,28 @@ jobs:
           path: |
             dist
           if-no-files-found: warn
+
+  e2e:
+    name: Playwright Tests
+    runs-on: ubuntu-latest
+    needs:
+      - lint
+      - typecheck
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps
+
+      - name: Run Playwright tests
+        run: npm run test:e2e

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@ node_modules
 .DS_Store
 dist
 .vite
+playwright-report
+test-results
 *.log
 .env
 .env.local

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
       },
       "devDependencies": {
         "@ladle/react": "^5.0.3",
+        "@playwright/test": "^1.55.0",
         "@types/node": "^20.12.7",
         "@types/react": "^18.2.48",
         "@types/react-dom": "^18.2.18",
@@ -2385,6 +2386,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.55.0.tgz",
+      "integrity": "sha512-04IXzPwHrW69XusN/SIdDdKZBzMfOT9UNT/YiJit/xpy2VuAoB8NHc8Aplb96zsWDddLnbkPL3TsmrS04ZU2xQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@radix-ui/primitive": {
@@ -10869,6 +10886,53 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.0.tgz",
+      "integrity": "sha512-sdCWStblvV1YU909Xqx0DhOjPZE4/5lJsIS84IfN9dAZfcl/CIZ5O8l3o0j7hPMjDvqoTF8ZUcc+i/GL5erstA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.0.tgz",
+      "integrity": "sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "test": "vitest run",
+    "test:e2e": "playwright test",
     "prepare": "husky"
   },
   "dependencies": {
@@ -39,6 +40,7 @@
   },
   "devDependencies": {
     "@ladle/react": "^5.0.3",
+    "@playwright/test": "^1.55.0",
     "@types/node": "^20.12.7",
     "@types/react": "^18.2.48",
     "@types/react-dom": "^18.2.18",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,39 @@
+import { defineConfig, devices } from '@playwright/test'
+
+const PORT = process.env.PORT ? Number(process.env.PORT) : 4173
+const CI = Boolean(process.env.CI)
+
+export default defineConfig({
+  testDir: './playwright/tests',
+  timeout: 60_000,
+  expect: {
+    timeout: 10_000,
+  },
+  fullyParallel: false,
+  forbidOnly: CI,
+  retries: CI ? 1 : 0,
+  reporter: [['html', { open: 'never' }], ['list']],
+  use: {
+    baseURL: `http://127.0.0.1:${PORT}`,
+    trace: 'on-first-retry',
+  },
+  webServer: {
+    command: `VITE_E2E=true npm run dev -- --host 0.0.0.0 --port ${PORT}`,
+    url: `http://127.0.0.1:${PORT}`,
+    reuseExistingServer: !CI,
+    stdout: 'pipe',
+    stderr: 'pipe',
+    env: {
+      ...process.env,
+      VITE_E2E: 'true',
+      VITE_CLERK_PUBLISHABLE_KEY: '',
+      PORT: String(PORT),
+    },
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+})

--- a/playwright/tests/auth.spec.ts
+++ b/playwright/tests/auth.spec.ts
@@ -1,0 +1,76 @@
+import { test, expect, type Page } from '@playwright/test'
+
+declare global {
+  interface Window {
+    __E2E_CLERK__?: {
+      reset: () => void
+      createUser: (input: {
+        email: string
+        password: string
+        firstName?: string
+        lastName?: string
+      }) => void
+      verificationCode: string
+    }
+  }
+}
+
+const TEST_VERIFICATION_CODE = '424242'
+const TEST_USER = {
+  name: 'Taylor Doe',
+  email: 'auth-e2e@example.com',
+  password: 'Password123!',
+}
+
+async function waitForClerkHelpers(page: Page) {
+  await page.waitForFunction(() => Boolean(window.__E2E_CLERK__))
+}
+
+test.describe('authentication flow', () => {
+  test.describe.configure({ mode: 'serial' })
+
+  test('allows a visitor to complete sign up', async ({ page }) => {
+    await page.goto('/sign-up')
+    await waitForClerkHelpers(page)
+    await page.evaluate(() => window.__E2E_CLERK__?.reset())
+
+    await page.getByLabel('Full name').fill(TEST_USER.name)
+    await page.getByLabel('Work email').fill(TEST_USER.email)
+    await page.getByLabel('Password').first().fill(TEST_USER.password)
+    await page.getByLabel('Confirm password').fill(TEST_USER.password)
+    await page.getByRole('button', { name: 'Create account' }).click()
+
+    await expect(page.getByText('We sent a verification code')).toBeVisible()
+    await page.getByLabel('Verification code').fill(TEST_VERIFICATION_CODE)
+    await page.getByRole('button', { name: 'Verify email' }).click()
+
+    await expect(page).toHaveURL(/\/dashboard/)
+    await expect(page.getByRole('heading', { name: 'Interactive counter' })).toBeVisible()
+  })
+
+  test('allows an existing user to sign in', async ({ page }) => {
+    await page.goto('/login')
+    await waitForClerkHelpers(page)
+    await page.evaluate(
+      ({ email, password }) => {
+        window.__E2E_CLERK__?.reset()
+        window.__E2E_CLERK__?.createUser({
+          email,
+          password,
+          firstName: 'Casey',
+          lastName: 'Tester',
+        })
+      },
+      { email: TEST_USER.email, password: TEST_USER.password },
+    )
+
+    await page.getByLabel('Email address').fill(TEST_USER.email)
+    await page.getByLabel('Password').fill(TEST_USER.password)
+    await page.getByRole('button', { name: 'Sign in' }).click()
+
+    await expect(page).toHaveURL(/\/dashboard/)
+    await expect(page.getByRole('heading', { name: 'Interactive counter' })).toBeVisible()
+  })
+})
+
+export {}

--- a/src/lib/clerk.tsx
+++ b/src/lib/clerk.tsx
@@ -13,53 +13,366 @@ import {
 
 type ChildrenProps = { children?: React.ReactNode }
 
+type SignInHookReturn = ReturnType<typeof realUseSignIn>
+type SignUpHookReturn = ReturnType<typeof realUseSignUp>
+type UseUserHookReturn = ReturnType<typeof realUseUser>
+type SignInSetActive = NonNullable<SignInHookReturn['setActive']>
+type SetActiveParams = Parameters<SignInSetActive>[0]
+
 const publishableKey = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY
 const placeholderPattern = /yourClerkKeyHere/i
+const e2eFlag = import.meta.env.VITE_E2E
 
 export const isClerkConfigured = Boolean(publishableKey && !placeholderPattern.test(publishableKey))
 export const clerkMissingKeyMessage =
   'Clerk authentication is not configured. Set VITE_CLERK_PUBLISHABLE_KEY to a valid key to enable sign in.'
 
-type SignInHookReturn = ReturnType<typeof realUseSignIn>
-type SignUpHookReturn = ReturnType<typeof realUseSignUp>
-type UseUserHookReturn = ReturnType<typeof realUseUser>
+const isE2ETestMode = !isClerkConfigured && (e2eFlag === 'true' || e2eFlag === '1')
+const TEST_VERIFICATION_CODE = '424242'
 
-const mockSignInValue = {
-  isLoaded: true,
-  signIn: {
-    async create() {
-      throw new Error(clerkMissingKeyMessage)
-    },
-  },
-  setActive: async () => {},
-} as unknown as SignInHookReturn
+type TestUserRecord = {
+  email: string
+  password: string
+  firstName?: string
+  lastName?: string
+}
 
-const mockSignUpValue = {
-  isLoaded: true,
-  signUp: {
-    async create() {
-      throw new Error(clerkMissingKeyMessage)
-    },
-    async prepareEmailAddressVerification() {
-      return
-    },
-    async attemptEmailAddressVerification() {
-      throw new Error(clerkMissingKeyMessage)
-    },
-  },
-  setActive: async () => {},
-} as unknown as SignUpHookReturn
+type TestVerificationRecord = {
+  email: string
+  password: string
+  firstName?: string
+  lastName?: string
+  code: string
+}
 
-const mockUserValue = {
-  isLoaded: true,
-  user: {
-    firstName: 'Avery',
-    lastName: 'Parker',
-    fullName: 'Avery Parker',
-    imageUrl: undefined,
-    primaryEmailAddress: { emailAddress: 'avery.parker@example.com' },
-  },
-} as unknown as UseUserHookReturn
+type TestHelpers = {
+  reset: () => void
+  createUser: (input: {
+    email: string
+    password: string
+    firstName?: string
+    lastName?: string
+  }) => void
+  verificationCode: string
+}
+
+type TestAuthState = {
+  users: Map<string, TestUserRecord>
+  sessions: Map<string, string>
+  activeSessionId: string | null
+  pendingVerification: TestVerificationRecord | null
+}
+
+type TestAuthAction =
+  | { type: 'RESET' }
+  | { type: 'ADD_USER'; user: TestUserRecord }
+  | { type: 'SET_PENDING_VERIFICATION'; record: TestVerificationRecord | null }
+  | { type: 'REGISTER_SESSION'; sessionId: string; email: string }
+  | { type: 'SET_ACTIVE_SESSION'; sessionId: string | null }
+
+type TestAuthContextValue = {
+  state: TestAuthState
+  dispatch: React.Dispatch<TestAuthAction>
+}
+
+type GlobalWithHelpers = typeof globalThis & { __E2E_CLERK__?: TestHelpers }
+type WindowWithHelpers = typeof window & { __E2E_CLERK__?: TestHelpers }
+
+const initialTestAuthState: TestAuthState = {
+  users: new Map(),
+  sessions: new Map(),
+  activeSessionId: null,
+  pendingVerification: null,
+}
+
+const TestAuthContext = React.createContext<TestAuthContextValue | null>(null)
+
+function testAuthReducer(state: TestAuthState, action: TestAuthAction): TestAuthState {
+  switch (action.type) {
+    case 'RESET':
+      return {
+        users: new Map(),
+        sessions: new Map(),
+        activeSessionId: null,
+        pendingVerification: null,
+      }
+    case 'ADD_USER': {
+      const users = new Map(state.users)
+      users.set(action.user.email, action.user)
+      return { ...state, users }
+    }
+    case 'SET_PENDING_VERIFICATION':
+      return { ...state, pendingVerification: action.record }
+    case 'REGISTER_SESSION': {
+      const sessions = new Map(state.sessions)
+      sessions.set(action.sessionId, action.email)
+      return { ...state, sessions, activeSessionId: action.sessionId }
+    }
+    case 'SET_ACTIVE_SESSION':
+      if (action.sessionId && !state.sessions.has(action.sessionId)) {
+        return state
+      }
+      return { ...state, activeSessionId: action.sessionId }
+    default:
+      return state
+  }
+}
+
+function useTestAuthContext(): TestAuthContextValue {
+  const context = React.useContext(TestAuthContext)
+
+  if (!context) {
+    throw new Error('Test auth context is not available')
+  }
+
+  return context
+}
+
+function normalizeEmail(email: string) {
+  return email.trim().toLowerCase()
+}
+
+function createTestHelpers(dispatch: React.Dispatch<TestAuthAction>): TestHelpers {
+  return {
+    reset: () => dispatch({ type: 'RESET' }),
+    createUser: ({ email, password, firstName, lastName }) => {
+      const normalizedEmail = normalizeEmail(email)
+      dispatch({
+        type: 'ADD_USER',
+        user: { email: normalizedEmail, password, firstName, lastName },
+      })
+    },
+    verificationCode: TEST_VERIFICATION_CODE,
+  }
+}
+
+function TestClerkProvider({ children }: ChildrenProps) {
+  const [state, dispatch] = React.useReducer(testAuthReducer, initialTestAuthState)
+
+  React.useEffect(() => {
+    const helpers = createTestHelpers(dispatch)
+    const globalWithHelpers = globalThis as GlobalWithHelpers
+    globalWithHelpers.__E2E_CLERK__ = helpers
+
+    if (typeof window !== 'undefined') {
+      ;(window as WindowWithHelpers).__E2E_CLERK__ = helpers
+    }
+
+    return () => {
+      if (globalWithHelpers.__E2E_CLERK__ === helpers) {
+        delete globalWithHelpers.__E2E_CLERK__
+      }
+
+      if (typeof window !== 'undefined') {
+        const windowWithHelpers = window as WindowWithHelpers
+
+        if (windowWithHelpers.__E2E_CLERK__ === helpers) {
+          delete windowWithHelpers.__E2E_CLERK__
+        }
+      }
+    }
+  }, [dispatch])
+
+  const value = React.useMemo(() => ({ state, dispatch }), [state])
+
+  return <TestAuthContext.Provider value={value}>{children}</TestAuthContext.Provider>
+}
+
+function useCreateSession() {
+  const { dispatch } = useTestAuthContext()
+
+  return React.useCallback(
+    (email: string) => {
+      const sessionId = `session-${Math.random().toString(36).slice(2)}`
+      dispatch({ type: 'REGISTER_SESSION', sessionId, email })
+      return sessionId
+    },
+    [dispatch],
+  )
+}
+
+function useSetActiveSession() {
+  const { state, dispatch } = useTestAuthContext()
+  const sessionsRef = React.useRef(state.sessions)
+
+  React.useEffect(() => {
+    sessionsRef.current = state.sessions
+  }, [state.sessions])
+
+  return React.useCallback(
+    async (params: SetActiveParams) => {
+      let sessionId: string | null | undefined = null
+
+      if (!params) {
+        sessionId = null
+      } else if (typeof params === 'string') {
+        sessionId = params
+      } else if (typeof params === 'object') {
+        if ('session' in params && params.session !== undefined) {
+          sessionId = params.session as string | null
+        } else if ('sessionId' in params && params.sessionId !== undefined) {
+          sessionId = params.sessionId as string | null
+        }
+      }
+
+      if (sessionId === null || sessionId === undefined) {
+        dispatch({ type: 'SET_ACTIVE_SESSION', sessionId: null })
+        return
+      }
+
+      const sessions = sessionsRef.current
+
+      if (!sessions.has(sessionId)) {
+        throw new Error('Session not found')
+      }
+
+      dispatch({ type: 'SET_ACTIVE_SESSION', sessionId })
+    },
+    [dispatch],
+  ) as SignInSetActive
+}
+
+function useE2ESignIn(): SignInHookReturn {
+  const { state } = useTestAuthContext()
+  const createSession = useCreateSession()
+  const setActive = useSetActiveSession()
+
+  return React.useMemo(
+    () =>
+      ({
+        isLoaded: true,
+        signIn: {
+          async create(params: { identifier: string; password: string }) {
+            const email = normalizeEmail(params.identifier)
+            const user = state.users.get(email)
+
+            if (!user || user.password !== params.password) {
+              throw new Error('Invalid email or password.')
+            }
+
+            const sessionId = createSession(email)
+            return { status: 'complete', createdSessionId: sessionId }
+          },
+        },
+        setActive,
+      }) as unknown as SignInHookReturn,
+    [state.users, createSession, setActive],
+  )
+}
+
+function useE2ESignUp(): SignUpHookReturn {
+  const { state, dispatch } = useTestAuthContext()
+  const createSession = useCreateSession()
+  const setActive = useSetActiveSession()
+
+  return React.useMemo(
+    () =>
+      ({
+        isLoaded: true,
+        signUp: {
+          async create(params: {
+            emailAddress: string
+            password: string
+            firstName?: string
+            lastName?: string
+          }) {
+            const email = normalizeEmail(params.emailAddress)
+
+            if (!email) {
+              throw new Error('Enter a valid email before continuing.')
+            }
+
+            if (state.users.has(email)) {
+              throw new Error('An account already exists with that email.')
+            }
+
+            dispatch({
+              type: 'SET_PENDING_VERIFICATION',
+              record: {
+                email,
+                password: params.password,
+                firstName: params.firstName,
+                lastName: params.lastName,
+                code: TEST_VERIFICATION_CODE,
+              },
+            })
+
+            return { status: 'needs_email_verification' }
+          },
+          async prepareEmailAddressVerification() {
+            return { status: 'prepared' }
+          },
+          async attemptEmailAddressVerification(params: { code: string }) {
+            const pending = state.pendingVerification
+
+            if (!pending) {
+              throw new Error('No sign-up attempt found.')
+            }
+
+            if (pending.code !== params.code.trim()) {
+              throw new Error('Invalid verification code.')
+            }
+
+            dispatch({ type: 'SET_PENDING_VERIFICATION', record: null })
+            dispatch({
+              type: 'ADD_USER',
+              user: {
+                email: pending.email,
+                password: pending.password,
+                firstName: pending.firstName,
+                lastName: pending.lastName,
+              },
+            })
+
+            const sessionId = createSession(pending.email)
+            return { status: 'complete', createdSessionId: sessionId }
+          },
+        },
+        setActive,
+      }) as unknown as SignUpHookReturn,
+    [state.pendingVerification, state.users, dispatch, createSession, setActive],
+  )
+}
+
+function useE2EUser(): UseUserHookReturn {
+  const { state } = useTestAuthContext()
+
+  return React.useMemo(() => {
+    const activeSessionId = state.activeSessionId
+
+    if (!activeSessionId) {
+      return { isLoaded: true, isSignedIn: false, user: null }
+    }
+
+    const email = state.sessions.get(activeSessionId)
+
+    if (!email) {
+      return { isLoaded: true, isSignedIn: false, user: null }
+    }
+
+    const record = state.users.get(email)
+
+    if (!record) {
+      return { isLoaded: true, isSignedIn: false, user: null }
+    }
+
+    const fullName = [record.firstName, record.lastName].filter(Boolean).join(' ') || undefined
+
+    return {
+      isLoaded: true,
+      isSignedIn: true,
+      user: {
+        id: `user_${email}`,
+        firstName: record.firstName,
+        lastName: record.lastName,
+        fullName,
+        imageUrl: null,
+        primaryEmailAddress: { emailAddress: email },
+        emailAddresses: [{ emailAddress: email }],
+      },
+    }
+  }, [state]) as unknown as UseUserHookReturn
+}
 
 function MockClerkProvider(props: ChildrenProps) {
   return <>{props.children}</>
@@ -97,6 +410,77 @@ function useMockUser(): UseUserHookReturn {
   return React.useMemo(() => mockUserValue, [])
 }
 
+function TestClerkLoaded(props: ChildrenProps) {
+  return <>{props.children}</>
+}
+
+function TestClerkLoading() {
+  return null
+}
+
+function TestSignedIn(props: ChildrenProps) {
+  const { state } = useTestAuthContext()
+
+  if (!state.activeSessionId) {
+    return null
+  }
+
+  return <>{props.children}</>
+}
+
+function TestSignedOut(props: ChildrenProps) {
+  const { state } = useTestAuthContext()
+
+  if (state.activeSessionId) {
+    return null
+  }
+
+  return <>{props.children}</>
+}
+
+function TestUserButton() {
+  return null
+}
+
+const mockSignInValue = {
+  isLoaded: true,
+  signIn: {
+    async create() {
+      throw new Error(clerkMissingKeyMessage)
+    },
+  },
+  setActive: async () => {},
+} as unknown as SignInHookReturn
+
+const mockSignUpValue = {
+  isLoaded: true,
+  signUp: {
+    async create() {
+      throw new Error(clerkMissingKeyMessage)
+    },
+    async prepareEmailAddressVerification() {
+      return
+    },
+    async attemptEmailAddressVerification() {
+      throw new Error(clerkMissingKeyMessage)
+    },
+  },
+  setActive: async () => {},
+} as unknown as SignUpHookReturn
+
+const mockUserValue = {
+  isLoaded: true,
+  isSignedIn: true,
+  user: {
+    firstName: 'Avery',
+    lastName: 'Parker',
+    fullName: 'Avery Parker',
+    imageUrl: undefined,
+    primaryEmailAddress: { emailAddress: 'avery.parker@example.com' },
+    emailAddresses: [{ emailAddress: 'avery.parker@example.com' }],
+  },
+} as unknown as UseUserHookReturn
+
 export function AppClerkProvider({ children }: ChildrenProps) {
   if (isClerkConfigured && publishableKey) {
     return (
@@ -107,6 +491,10 @@ export function AppClerkProvider({ children }: ChildrenProps) {
         {children}
       </RealClerkProvider>
     )
+  }
+
+  if (isE2ETestMode) {
+    return <TestClerkProvider>{children}</TestClerkProvider>
   }
 
   if (!publishableKey) {
@@ -122,14 +510,42 @@ export function AppClerkProvider({ children }: ChildrenProps) {
   return <MockClerkProvider>{children}</MockClerkProvider>
 }
 
-export const ClerkLoaded = isClerkConfigured ? RealClerkLoaded : MockClerkLoaded
-export const ClerkLoading = isClerkConfigured ? RealClerkLoading : MockClerkLoading
-export const SignedIn = isClerkConfigured ? RealSignedIn : MockSignedIn
-export const SignedOut = isClerkConfigured ? RealSignedOut : MockSignedOut
-export const UserButton = isClerkConfigured ? RealUserButton : MockUserButton
-export const useSignIn = isClerkConfigured ? realUseSignIn : useMockSignIn
-export const useSignUp = isClerkConfigured ? realUseSignUp : useMockSignUp
-export const useUser = isClerkConfigured ? realUseUser : useMockUser
+export const ClerkLoaded = isClerkConfigured
+  ? RealClerkLoaded
+  : isE2ETestMode
+    ? TestClerkLoaded
+    : MockClerkLoaded
+export const ClerkLoading = isClerkConfigured
+  ? RealClerkLoading
+  : isE2ETestMode
+    ? TestClerkLoading
+    : MockClerkLoading
+export const SignedIn = isClerkConfigured
+  ? RealSignedIn
+  : isE2ETestMode
+    ? TestSignedIn
+    : MockSignedIn
+export const SignedOut = isClerkConfigured
+  ? RealSignedOut
+  : isE2ETestMode
+    ? TestSignedOut
+    : MockSignedOut
+export const UserButton = isClerkConfigured
+  ? RealUserButton
+  : isE2ETestMode
+    ? TestUserButton
+    : MockUserButton
+export const useSignIn = isClerkConfigured
+  ? realUseSignIn
+  : isE2ETestMode
+    ? useE2ESignIn
+    : useMockSignIn
+export const useSignUp = isClerkConfigured
+  ? realUseSignUp
+  : isE2ETestMode
+    ? useE2ESignUp
+    : useMockSignUp
+export const useUser = isClerkConfigured ? realUseUser : isE2ETestMode ? useE2EUser : useMockUser
 
 export function getClerkErrorMessage(error: unknown): string | null {
   if (typeof error === 'object' && error !== null && 'errors' in error) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,6 @@
       "@/*": ["src/*"]
     }
   },
-  "include": ["src", ".ladle", "vite.config.ts"],
+  "include": ["src", ".ladle", "vite.config.ts", "playwright"],
   "exclude": ["node_modules"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,7 @@ import { fileURLToPath } from 'node:url'
 
 import react from '@vitejs/plugin-react'
 import { defineConfig } from 'vite'
+import { configDefaults } from 'vitest/config'
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url))
 
@@ -17,5 +18,6 @@ export default defineConfig({
     globals: true,
     environment: 'jsdom',
     passWithNoTests: true,
+    exclude: [...configDefaults.exclude, 'playwright/**'],
   },
 })


### PR DESCRIPTION
## Summary
- add an in-memory Clerk test provider that powers sign-in/sign-up flows when VITE_E2E is enabled
- create Playwright configuration and end-to-end tests that exercise sign-up and login journeys
- wire Playwright into local tooling (scripts, tsconfig, vite config, gitignore) and CI

## Testing
- npm run lint
- npm run typecheck
- npm run test
- npm run build
- npx playwright test

------
https://chatgpt.com/codex/tasks/task_e_68d01861681c8329bca3207ecd28da78